### PR TITLE
feat: allow bech32 receiver, looked up in home.namesByAddress

### DIFF
--- a/api/deploy.js
+++ b/api/deploy.js
@@ -6,6 +6,7 @@ import { E } from '@agoric/eventual-send';
 import installationConstants from '../ui.old/public/conf/installationConstants';
 
 import '@agoric/zoe/exported';
+import '@agoric/swingset-vat/exported';
 
 // deploy.js runs in an ephemeral Node.js outside of swingset. The
 // spawner runs within ag-solo, so is persistent.  Once the deploy.js
@@ -45,10 +46,11 @@ export default async function deployApi(
     zoe: untypedZoe,
 
     board,
+    namesByAddress,
     ibcport: untypedPorts,
   } = home;
 
-  /** @type {import('@agoric/swingset-vat/src/vats/network').Port[]} */
+  /** @type {Array<Port>} */
   const ibcport = untypedPorts;
 
   /** @type {ZoeService} */
@@ -65,7 +67,7 @@ export default async function deployApi(
   const { instance } = await E(zoe).startInstance(
     pegasusContractInstallationHandle,
     {},
-    { board },
+    { board, namesByAddress },
   );
   console.log('- SUCCESS! contract instance is running on Zoe');
 


### PR DESCRIPTION
This is the minimal change needed to support finding depositFacets from the bech32 address of the wallet client.  We expect the wallet to do something like:

```js
E(home.myAddressNameAdmin).update('depositFacet', myDepositFacet);
```

and then to display:

```js
E(home.myAddressNameAdmin).getMyAddress();
```

(the wallet's Cosmos address in bech32 format) to the user in her wallet UI.  Then that address can be used as a receiver for a Pegasus transfer.
