### PR TITLE
chore: Force upgrade trim dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "agoric": "*",
     "babel-eslint": ">=11.0.0-beta.2",
     "eslint-plugin-eslint-comments": "^3.1.2"
+  },
+  "resolutions": {
+    "**/trim": "^0.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4889,10 +4889,10 @@ trim-off-newlines@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+trim@0.0.1, trim@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
+  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
Dependabot was unable to mitigate a regular expression denial of service issue in the supply chain. `trim 0.0.1` contains a vulnerability that is fixed in `0.0.3`, and `tap-out` is pinned to the `0.0.1` release train. We use a yarn `resolutions` entry to override.
